### PR TITLE
Squeak/Pharo compatible class detection

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -3,7 +3,7 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'MaterialDesignLite',
       #directory : 'src',
-      #platforms : [ #pharo ]
+      #platforms : [ #squeak, #pharo ]
     }
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ os:
 smalltalk:
   - Pharo-6.0
   - Pharo-5.0
+  - Squeak-5.1

--- a/src/BaselineOfMaterialDesignLite.package/BaselineOfMaterialDesignLite.class/instance/projectClass.st
+++ b/src/BaselineOfMaterialDesignLite.package/BaselineOfMaterialDesignLite.class/instance/projectClass.st
@@ -1,9 +1,9 @@
-accessing
 projectClass
 	self flag: #clean.	"This is a hack that need to be remove after the default version of Metacello includes Cypress suport."
-	^ [ #MetacelloCypressBaselineProject asClass ]
-		on: NotFound
-		do: [ Metacello new
+	^ (Smalltalk hasClassNamed: 'MetacelloCypressBaselineProject')
+		ifTrue: [Smalltalk classNamed: 'MetacelloCypressBaselineProject']
+		ifFalse: [
+			Metacello new
 				baseline: 'Metacello';
 				repository: 'github://dalehenrich/metacello-work:master/repository';
 				get.

--- a/src/BaselineOfMaterialDesignLite.package/BaselineOfMaterialDesignLite.class/instance/projectClass.st
+++ b/src/BaselineOfMaterialDesignLite.package/BaselineOfMaterialDesignLite.class/instance/projectClass.st
@@ -1,3 +1,4 @@
+accessing
 projectClass
 	self flag: #clean.	"This is a hack that need to be remove after the default version of Metacello includes Cypress suport."
 	^ (Smalltalk hasClassNamed: 'MetacelloCypressBaselineProject')


### PR DESCRIPTION
This way, both Squeak and Pharo can tell whether they know about `MetacelloCypressBaselineProject`
