### PR TITLE
[MDLDemoScreen>>codeOf] Avoid `cr` and make Squeak-compatible 

### DIFF
--- a/src/Material-Design-Lite-Core.package/MDLDemoScreen.class/instance/codeOf..st
+++ b/src/Material-Design-Lite-Core.package/MDLDemoScreen.class/instance/codeOf..st
@@ -1,5 +1,5 @@
 accessing
-codeOf: aSymbole
+codeOf: aSymbol
 	"I take a method selector I contains and return his source code without the declaration."
 
 	^ String streamContents: [:stream |

--- a/src/Material-Design-Lite-Core.package/MDLDemoScreen.class/instance/codeOf..st
+++ b/src/Material-Design-Lite-Core.package/MDLDemoScreen.class/instance/codeOf..st
@@ -2,7 +2,7 @@ accessing
 codeOf: aSymbole
 	"I take a method selector I contains and return his source code without the declaration."
 
-	self
-		flag:
-			#'For now the line ending in Pharo is cr but it will change in the future. Infortunatly there is no way to know the current line ending, so this method will need to be updated by hand during the change.'.
-	^ (self class >> aSymbole) sourceCode copyAfter: Character cr
+	^ String streamContents: [:stream |
+		(self class sourceCodeAt: aSymbol) lines allButFirst
+			do: [:ea | stream nextPutAll: ea]
+			separatedBy: [stream nextPutAll: GRPlatform current newline]]


### PR DESCRIPTION
(Squeak does not have #sourceCode on CompiledMethod but this way we avoid the compiled method altogether

second try