### PR TITLE
220-Use-Named-URLs-in-demos-to-make-it-easier-to-share-demos

### DIFF
--- a/src/Material-Design-Lite-Core/MaterialDesignLite.class.st
+++ b/src/Material-Design-Lite-Core/MaterialDesignLite.class.st
@@ -18,7 +18,7 @@ MaterialDesignLite class >> mainMenuCommandOn: aBuilder [
 		icon: (self mdlIcon scaledToSize: 16@16)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 MaterialDesignLite class >> mdlIcon [
 	^ PNGReadWriter formFromStream: MDLLibrary default logoPng readStream
 ]

--- a/src/Material-Design-Lite-Demo/MDLDemo.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemo.class.st
@@ -159,7 +159,7 @@ MDLDemo >> initialRequest: aRequest [
 	
 	"Try to find a page corresponding"
 	self header possiblePages
-		detect: [ :each | each pathName = pageName ]
+		detect: [ :each | each pathName asLowercase = pageName ]
 		ifFound: [ :class | 
 			self displayInstanceOf: class.
 

--- a/src/Material-Design-Lite-Demo/MDLDemo.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemo.class.st
@@ -155,7 +155,7 @@ MDLDemo >> initialRequest: aRequest [
 	"If we are at end, nothing to manage"
 	consumer atEnd ifTrue: [ ^ self ].
 	
-	pageName := consumer peek.
+	pageName := consumer peek asLowercase. "Do not make URLs case sensitive in that case"
 	
 	"Try to find a page corresponding"
 	self header possiblePages

--- a/src/Material-Design-Lite-Demo/MDLDemo.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemo.class.st
@@ -146,6 +146,27 @@ MDLDemo >> header: anObject [
 	header := anObject
 ]
 
+{ #category : #hooks }
+MDLDemo >> initialRequest: aRequest [
+	| consumer pageName |
+	super initialRequest: aRequest.
+	consumer := self requestContext consumer.
+	
+	"If we are at end, nothing to manage"
+	consumer atEnd ifTrue: [ ^ self ].
+	
+	pageName := consumer peek.
+	
+	"Try to find a page corresponding"
+	self header possiblePages
+		detect: [ :each | each pathName = pageName ]
+		ifFound: [ :class | 
+			self displayInstanceOf: class.
+
+			"If we find a page, we pop the subpart of the path corresponding to the page."
+			consumer next ]
+]
+
 { #category : #initialization }
 MDLDemo >> initialize [
 	super initialize.
@@ -217,6 +238,12 @@ MDLDemo >> updateTabIconRoot: anHtmlRoot [
 	anHtmlRoot meta
 		name: 'theme-color';
 		content: '#ffffff'
+]
+
+{ #category : #updating }
+MDLDemo >> updateUrl: aUrl [
+	super updateUrl: aUrl.
+	aUrl addToPath: (self componentToDisplay pathName)
 ]
 
 { #category : #accessing }

--- a/src/Material-Design-Lite-Demo/MDLDemoPage.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemoPage.class.st
@@ -29,7 +29,7 @@ MDLDemoPage class >> pagesToDisplay [
 MDLDemoPage class >> pathName [
 	"Use to define the URL name"
 
-	^ (self pageName copyWithout: $ ) asLowercase 
+	^ self pageName copyWithout: $  
 ]
 
 { #category : #accessing }

--- a/src/Material-Design-Lite-Demo/MDLDemoPage.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemoPage.class.st
@@ -26,6 +26,18 @@ MDLDemoPage class >> pagesToDisplay [
 ]
 
 { #category : #accessing }
+MDLDemoPage class >> pathName [
+	"Use to define the URL name"
+
+	^ (self pageName copyWithout: $ ) asLowercase 
+]
+
+{ #category : #accessing }
 MDLDemoPage class >> priority [
 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+MDLDemoPage >> pathName [
+	^ self class pathName
 ]

--- a/src/Material-Design-Lite-Demo/MDLDemoPageWithList.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemoPageWithList.class.st
@@ -36,6 +36,32 @@ MDLDemoPageWithList >> defaultList [
 		yourself
 ]
 
+{ #category : #testing }
+MDLDemoPageWithList >> hasScreenSelected [
+	^ self selectedScreen isNotNil
+]
+
+{ #category : #hooks }
+MDLDemoPageWithList >> initialRequest: aRequest [
+	| consumer pageName |
+	super initialRequest: aRequest.
+	consumer := self requestContext consumer.
+	
+	"If we are at end, nothing to manage"
+	consumer atEnd ifTrue: [ ^ self ].
+	
+	pageName := consumer peek asLowercase. "Do not make URLs case sensitive in that case"
+	
+	"Try to find a page corresponding"
+	self sortedScreens
+		detect: [ :each | each pathName asLowercase = pageName ]
+		ifFound: [ :class | 
+			self select: class.
+
+			"If we find a page, we pop the subpart of the path corresponding to the page."
+			consumer next ]
+]
+
 { #category : #initialization }
 MDLDemoPageWithList >> initialize [
 	super initialize.
@@ -113,4 +139,10 @@ MDLDemoPageWithList >> selectedScreen: aScreen [
 { #category : #accessing }
 MDLDemoPageWithList >> sortedScreens [
 	^ self screens sorted: [ :a :b | a title < b title ]
+]
+
+{ #category : #updating }
+MDLDemoPageWithList >> updateUrl: aUrl [
+	super updateUrl: aUrl.
+	self selectedScreen ifNotNil: [ :screen | aUrl addToPath: screen pathName ]
 ]

--- a/src/Material-Design-Lite-Demo/MDLDemoScreen.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemoScreen.class.st
@@ -32,6 +32,11 @@ MDLDemoScreen class >> iconUrl [
 ]
 
 { #category : #accessing }
+MDLDemoScreen class >> pathName [
+	^ self title copyWithout: $ 
+]
+
+{ #category : #accessing }
 MDLDemoScreen class >> title [
 	"I should return the title of the component screen."
 
@@ -41,6 +46,11 @@ MDLDemoScreen class >> title [
 { #category : #accessing }
 MDLDemoScreen >> description [
 	^ self class description
+]
+
+{ #category : #accessing }
+MDLDemoScreen >> pathName [
+	^ self class pathName
 ]
 
 { #category : #rendering }


### PR DESCRIPTION
Also fix URLs of examples. 

Fixes #220