### PR TITLE
225-Update-Magritte-dependency-to-load-version-from-Github-

### DIFF
--- a/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
+++ b/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
@@ -27,7 +27,7 @@ BaselineOfMaterialDesignLite >> baseline: spec [
 				package: 'Material-Design-Lite-Core' with: [ spec requires: #('Material-Design-Lite-Utils' 'Material-Design-Lite-Components' 'Material-Design-Lite-Widgets' 'Material-Design-Lite-Extensions') ];
 				package: 'Material-Design-Lite-Core-Tests' with: [ spec requires: #('Material-Design-Lite-Core' 'Material-Design-Lite-Components-Tests') ];
 				package: 'Material-Design-Lite-Demo' with: [ spec requires: #('Material-Design-Lite-Core') ];
-				package: 'Material-Design-Lite-Magritte' with: [ spec requires: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components') ];
+				package: 'Material-Design-Lite-Magritte' with: [ spec requires: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components' 'Magritte3') ];
 				package: 'Material-Design-Lite-Widgets' with: [ spec requires: #('Material-Design-Lite-Components') ];
 				package: 'Material-Design-Lite-Widgets-Tests' with: [ spec requires: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components-Tests') ];
 				package: 'Material-Design-Lite-Utils' with: [ spec requires: #('Seaside3' 'FileLibraryHelper') ];
@@ -57,8 +57,9 @@ BaselineOfMaterialDesignLite >> fileLibraryHelper: spec [
 { #category : #dependencies }
 BaselineOfMaterialDesignLite >> magritte: spec [
 	spec
-		baseline: 'Magritte'
+		project: 'Magritte3'
 		with: [ spec
+				className: 'BaselineOfMagritte';
 				loads: #('Seaside');
 				repository: 'github://magritte-metamodel/magritte:v3.5.4/source' ]
 ]

--- a/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
+++ b/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
@@ -4,7 +4,7 @@ I am a baseline of MaterialDesignLite. Read more at: https://github.com/DuneSt/M
 Class {
 	#name : #BaselineOfMaterialDesignLite,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfMaterialDesignLite'
+	#category : #BaselineOfMaterialDesignLite
 }
 
 { #category : #baseline }
@@ -57,12 +57,10 @@ BaselineOfMaterialDesignLite >> fileLibraryHelper: spec [
 { #category : #dependencies }
 BaselineOfMaterialDesignLite >> magritte: spec [
 	spec
-		project: 'Magritte3'
+		baseline: 'Magritte'
 		with: [ spec
-				className: #ConfigurationOfMagritte3;
-				versionString: #'release3';
 				loads: #('Seaside');
-				repository: 'http://smalltalkhub.com/mc/Magritte/Magritte3/main/' ]
+				repository: 'github://magritte-metamodel/magritte:v3.5.4/source' ]
 ]
 
 { #category : #dependencies }

--- a/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
+++ b/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
@@ -59,7 +59,7 @@ BaselineOfMaterialDesignLite >> magritte: spec [
 	spec
 		project: 'Magritte3'
 		with: [ spec
-				className: 'BaselineOfMagritte';
+				className: 'Magritte';
 				loads: #('Seaside');
 				repository: 'github://magritte-metamodel/magritte:v3.5.4/source' ]
 ]

--- a/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
+++ b/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
@@ -26,22 +26,22 @@ BaselineOfMaterialDesignLite >> baseline: spec [
 				package: 'Material-Design-Lite-Components-Tests' with: [ spec requires: #('Material-Design-Lite-Components') ];
 				package: 'Material-Design-Lite-Core' with: [ spec requires: #('Material-Design-Lite-Utils' 'Material-Design-Lite-Components' 'Material-Design-Lite-Widgets' 'Material-Design-Lite-Extensions') ];
 				package: 'Material-Design-Lite-Core-Tests' with: [ spec requires: #('Material-Design-Lite-Core' 'Material-Design-Lite-Components-Tests') ];
-				package: 'Material-Design-Lite-Demo' with: [ spec requires: #('Material-Design-Lite-Core') ];
-				package: 'Material-Design-Lite-Magritte' with: [ spec requires: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components' 'Magritte3') ];
 				package: 'Material-Design-Lite-Widgets' with: [ spec requires: #('Material-Design-Lite-Components') ];
 				package: 'Material-Design-Lite-Widgets-Tests' with: [ spec requires: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components-Tests') ];
-				package: 'Material-Design-Lite-Utils' with: [ spec requires: #('Seaside3' 'FileLibraryHelper') ];
 				package: 'Material-Design-Lite-Extensions' with: [ spec requires: #('Material-Design-Lite-Utils' 'Material-Design-Lite-Components') ];
-				package: 'Material-Design-Lite-Extensions-Tests' with: [ spec requires: #('Material-Design-Lite-Extensions' 'Material-Design-Lite-Components-Tests') ].
+				package: 'Material-Design-Lite-Extensions-Tests' with: [ spec requires: #('Material-Design-Lite-Extensions' 'Material-Design-Lite-Components-Tests') ];
+				package: 'Material-Design-Lite-Utils' with: [ spec requires: #('Seaside3' 'FileLibraryHelper') ];
+				package: 'Material-Design-Lite-Demo' with: [ spec requires: #('Material-Design-Lite-Core') ];
+				package: 'Material-Design-Lite-Magritte' with: [ spec requires: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components' 'Magritte') ].
 			
 			"Groups"
 			spec
-				group: 'Magritte' with: #('Material-Design-Lite-Magritte');
 				group: 'all' with: #('default' 'Magritte');
 				group: 'extensions' with: #('Material-Design-Lite-Extensions');
 				group: 'core' with: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components' 'Material-Design-Lite-Core' 'Material-Design-Lite-Utils');
 				group: 'default' with: #('core' 'tests' 'demo');
 				group: 'demo' with: #('Material-Design-Lite-Demo');
+				group: 'magritte' with: #('Material-Design-Lite-Magritte');
 				group: 'tests' with: #('Material-Design-Lite-Components-Tests' 'Material-Design-Lite-Widgets-Tests' 'Material-Design-Lite-Extensions-Tests' 'Material-Design-Lite-Core-Tests') ]
 ]
 
@@ -57,9 +57,8 @@ BaselineOfMaterialDesignLite >> fileLibraryHelper: spec [
 { #category : #dependencies }
 BaselineOfMaterialDesignLite >> magritte: spec [
 	spec
-		project: 'Magritte3'
+		baseline: 'Magritte'
 		with: [ spec
-				className: 'Magritte';
 				loads: #('Seaside');
 				repository: 'github://magritte-metamodel/magritte:v3.5.4/source' ]
 ]

--- a/src/Material-Design-Lite-Demo/MDLDemo.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemo.class.st
@@ -81,7 +81,7 @@ MDLDemo class >> open [
 
 { #category : #versions }
 MDLDemo class >> version [
-	^ 'v2.0.0'
+	^ 'v2.0.1'
 ]
 
 { #category : #hooks }


### PR DESCRIPTION
Update Magritte to https://github.com/magritte-metamodel/magritte

Fixes #225