### PR TITLE
231-Allow-to-set-tooltip-position-in-MDLMenuButtonWidget

### DIFF
--- a/src/Material-Design-Lite-Widgets-Tests/MDLMenuButtonWidgetTests.class.st
+++ b/src/Material-Design-Lite-Widgets-Tests/MDLMenuButtonWidgetTests.class.st
@@ -24,6 +24,36 @@ MDLMenuButtonWidgetTests >> testButtonContents [
 ]
 
 { #category : #tests }
+MDLMenuButtonWidgetTests >> testDefaultDescriptionPositionAtBottom [
+	self assert: menu descriptionPosition equals: #bottom
+]
+
+{ #category : #tests }
+MDLMenuButtonWidgetTests >> testDescriptionAtBottom [
+	menu descriptionAtBottom.
+	
+	self assert: menu descriptionPosition equals: #bottom
+]
+
+{ #category : #tests }
+MDLMenuButtonWidgetTests >> testDescriptionAtLeft [
+	menu descriptionAtLeft.
+	self assert: menu descriptionPosition equals: #left
+]
+
+{ #category : #tests }
+MDLMenuButtonWidgetTests >> testDescriptionAtRight [
+	menu descriptionAtRight.
+	self assert: menu descriptionPosition equals: #right
+]
+
+{ #category : #tests }
+MDLMenuButtonWidgetTests >> testDescriptionAtTop [
+	menu descriptionAtTop.
+	self assert: menu descriptionPosition equals: #top
+]
+
+{ #category : #tests }
 MDLMenuButtonWidgetTests >> testLabelFor [
 	menu textBlock: nil.
 	self assert: (menu labelFor: 3) equals: '3'.

--- a/src/Material-Design-Lite-Widgets-Tests/MDLMenuButtonWidgetTests.class.st
+++ b/src/Material-Design-Lite-Widgets-Tests/MDLMenuButtonWidgetTests.class.st
@@ -38,7 +38,9 @@ MDLMenuButtonWidgetTests >> testDescriptionAtBottom [
 { #category : #tests }
 MDLMenuButtonWidgetTests >> testDescriptionAtLeft [
 	menu descriptionAtLeft.
-	self assert: menu descriptionPosition equals: #left
+	menu description: 'Description'.
+	self assert: menu descriptionPosition equals: #left.
+	self assert: [ :html | html render: menu ] generatedIncludes: 'mdl-tooltip--left'
 ]
 
 { #category : #tests }

--- a/src/Material-Design-Lite-Widgets/MDLMenuButtonWidget.class.st
+++ b/src/Material-Design-Lite-Widgets/MDLMenuButtonWidget.class.st
@@ -39,7 +39,8 @@ Class {
 		'description',
 		'action',
 		'sortBlock',
-		'buttonContent'
+		'buttonContent',
+		'descriptionPosition'
 	],
 	#category : #'Material-Design-Lite-Widgets-Menu'
 }
@@ -134,6 +135,40 @@ MDLMenuButtonWidget >> description: anObject [
 	description := anObject
 ]
 
+{ #category : #options }
+MDLMenuButtonWidget >> descriptionAtBottom [
+	"Sets the description of the menu at its bottom."
+	self descriptionPosition: #bottom
+]
+
+{ #category : #options }
+MDLMenuButtonWidget >> descriptionAtLeft [
+	"Sets the description of the menu at its left."
+	self descriptionPosition: #left
+]
+
+{ #category : #options }
+MDLMenuButtonWidget >> descriptionAtRight [
+	"Sets the description of the menu at its right."
+	self descriptionPosition: #right
+]
+
+{ #category : #options }
+MDLMenuButtonWidget >> descriptionAtTop [
+	"Sets the description of the menu at its top."
+	self descriptionPosition: #top
+]
+
+{ #category : #accessing }
+MDLMenuButtonWidget >> descriptionPosition [
+	^ descriptionPosition ifNil: [ descriptionPosition := #bottom ]
+]
+
+{ #category : #accessing }
+MDLMenuButtonWidget >> descriptionPosition: anObject [
+	descriptionPosition := anObject
+]
+
 { #category : #private }
 MDLMenuButtonWidget >> labelFor: anObject [
 	^ self textBlock ifNil: [ anObject asString ] ifNotNil: [ :tb | tb cull: anObject ]
@@ -206,6 +241,7 @@ MDLMenuButtonWidget >> renderTooltipOn: html [
 	html mdlTooltip
 		for: self id;
 		large;
+		position: self descriptionPosition;
 		with: self description
 ]
 


### PR DESCRIPTION
Fix issue #231 .

Implemented methods allowing to set the position of the tooltip.

The default position is `bottom`. Like that, if no configuration of the position is done, the behaviour is retro-compatible.

Implemented tests as well.