### PR TITLE
v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!--git log --pretty="* %s ([%h](https://github.com/DuneSt/MaterialDesignLite/commit/%H))" v1.3.2...HEAD-->
 
 
+# [v2.1.1](https://github.com/DuneSt/MaterialDesignLite/compare/v2.1.0...v2.1.1) (2019-02-11)
+
+## Bug fix
+
+* Fix broken `all` group in Baseline ([cb6db74](https://github.com/DuneSt/MaterialDesignLite/commit/cb6db7476faa70a86d32d8be394d61a25bcc01cd))
+
 # [v2.1.0](https://github.com/DuneSt/MaterialDesignLite/compare/v2.0.1...v2.1.0) (2019-02-07)
 
 ## Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!--git log --pretty="* %s ([%h](https://github.com/DuneSt/MaterialDesignLite/commit/%H)) v1.3.2...HEAD --grep="Merge "-->
+# [v2.1.3](https://github.com/DuneSt/MaterialDesignLite/compare/v2.1.2...v2.1.3) (2019-03-09)
 
+## Infrastructure
+
+* Fix version of FileLibraryHelper to v1.x.x ([808cffb](https://github.com/DuneSt/MaterialDesignLite/commit/808cffbf5a03c7f0fe5bfe84213239afaa43b971))
 
 # [v2.1.2](https://github.com/DuneSt/MaterialDesignLite/compare/v2.1.1...v2.1.2) (2019-02-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!--git log --pretty="* %s ([%h](https://github.com/DuneSt/MaterialDesignLite/commit/%H))" v1.3.2...HEAD-->
 
-# [v2.0.0](https://github.com/DuneSt/MaterialDesignLite/compare/v1.3.3...v2.0.0) (2010-01-10)
+# [v2.0.1](https://github.com/DuneSt/MaterialDesignLite/compare/v2.0.0...v2.0.1) (2019-01-24)
+
+## Infastructure
+
+* Update Magritte dependency to github one ([e597e12](https://github.com/DuneSt/MaterialDesignLite/commit/e597e12668d792fd23d1f717a6be5937ce14e316))
+
+# [v2.0.0](https://github.com/DuneSt/MaterialDesignLite/compare/v1.3.3...v2.0.0) (2019-01-10)
 
 ## BREAKING CHANGES
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ To add MaterialDesignLite Seaside to your baseline just add this:
 ```
 ### In GemStone
 
+Gemstone is only supported on v1 of the project. This does not mean no fix or feature can be added to it. We can still release new patch and feature version if asked.
+
 ```Smalltalk
     Metacello new
     	githubUser: 'DuneSt' project: 'MaterialDesignLite' commitish: 'v1.x.x' path: 'src';

--- a/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
+++ b/src/BaselineOfMaterialDesignLite/BaselineOfMaterialDesignLite.class.st
@@ -36,7 +36,7 @@ BaselineOfMaterialDesignLite >> baseline: spec [
 			
 			"Groups"
 			spec
-				group: 'all' with: #('default' 'Magritte');
+				group: 'all' with: #('default' 'magritte');
 				group: 'extensions' with: #('Material-Design-Lite-Extensions');
 				group: 'core' with: #('Material-Design-Lite-Widgets' 'Material-Design-Lite-Components' 'Material-Design-Lite-Core' 'Material-Design-Lite-Utils');
 				group: 'default' with: #('core' 'tests' 'demo');

--- a/src/Material-Design-Lite-Demo/MDLDemo.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemo.class.st
@@ -81,7 +81,7 @@ MDLDemo class >> open [
 
 { #category : #versions }
 MDLDemo class >> version [
-	^ 'v2.1.0'
+	^ 'v2.1.1'
 ]
 
 { #category : #hooks }

--- a/src/Material-Design-Lite-Demo/MDLDemo.class.st
+++ b/src/Material-Design-Lite-Demo/MDLDemo.class.st
@@ -81,7 +81,7 @@ MDLDemo class >> open [
 
 { #category : #versions }
 MDLDemo class >> version [
-	^ 'v2.1.2'
+	^ 'v2.1.3'
 ]
 
 { #category : #hooks }


### PR DESCRIPTION
# [v2.1.3](https://github.com/DuneSt/MaterialDesignLite/compare/v2.1.2...v2.1.3) (2019-03-09)

## Infrastructure

* Fix version of FileLibraryHelper to v1.x.x ([808cffb](https://github.com/DuneSt/MaterialDesignLite/commit/808cffbf5a03c7f0fe5bfe84213239afaa43b971))
