### PR TITLE
Add-more-description-to-menu-demo

### DIFF
--- a/src/Material-Design-Lite-Demo/MDLMenusScreen.class.st
+++ b/src/Material-Design-Lite-Demo/MDLMenusScreen.class.st
@@ -4,12 +4,12 @@ I'm representing the menu components screen
 Class {
 	#name : #MDLMenusScreen,
 	#superclass : #MDLComponentDemo,
-	#category : 'Material-Design-Lite-Demo-Components'
+	#category : #'Material-Design-Lite-Demo-Components'
 }
 
 { #category : #accessing }
 MDLMenusScreen class >> description [
-	^ 'Lists of clickable actions.'
+	^ 'Lists of clickable actions. Those menus are anchored to elements and can have their anchor point specified.'
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Improve description of menu demo to say that positions are for the anchor points of the menus and not the position of the icon on the page.