### PR TITLE
186-MDLCalendarWidget-active-month-is-not-highlighted

### DIFF
--- a/src/Material-Design-Lite-Widgets-Tests/MDLDatePickerTest.class.st
+++ b/src/Material-Design-Lite-Widgets-Tests/MDLDatePickerTest.class.st
@@ -94,14 +94,14 @@ MDLDatePickerTest >> testJsOnCompleteScript [
 MDLDatePickerTest >> testRenderMonthesOn [
 	self assert: [ :html | calendar renderMonthesOn: html ] generatedIncludesAll: Date monthNames.
 	calendar currentDate: (Date year: 2018 month: 6 day: 5).
-	self assert: [ :html | calendar renderMonthesOn: html ] generatedIncludes: 'May</div><div class="mdl-cell month-cell active mdl-cell--4-col-desktop"' "June need to be active"
+	self assert: [ :html | calendar renderMonthesOn: html ] generatedIncludes: 'May</div><div class="mdl-cell month-cell mdl-color-text--primary mdl-color-text--primary-contrast mdl-color--primary active mdl-cell--4-col-desktop"' "Needs to be active and get additional classes to show it selected."
 ]
 
 { #category : #tests }
 MDLDatePickerTest >> testRenderYearsOn [
 	self assert: [ :html | calendar renderYearsOn: html ] generatedIncludesAll: (calendar calendar yearsInterval collect: #asString).
 	calendar currentDate: (Date year: 2018 month: 6 day: 5).
-	self assert: [ :html | calendar renderYearsOn: html ] generatedIncludes: '2017</div><div class="mdl-cell year-cell active mdl-cell--4-col-desktop"' "2018 need to be active"
+	self assert: [ :html | calendar renderYearsOn: html ] generatedIncludes: '2017</div><div class="mdl-cell year-cell mdl-color-text--primary mdl-color-text--primary-contrast mdl-color--primary active mdl-cell--4-col-desktop"' "2018 need to be active"
 ]
 
 { #category : #tests }

--- a/src/Material-Design-Lite-Widgets/MDLFlatDatePicker.class.st
+++ b/src/Material-Design-Lite-Widgets/MDLFlatDatePicker.class.st
@@ -259,6 +259,9 @@ MDLFlatDatePicker >> renderMonthesOn: html [
 				do: [ :aString | 
 					html mdlCell
 						class: 'month-cell';
+						class: 'mdl-color-text--primary' if: aString = self currentDate monthName;
+						class: 'mdl-color-text--primary-contrast' if: aString = self currentDate monthName;
+						class: 'mdl-color--primary' if: aString = self currentDate monthName;
 						class: 'active' if: aString = self currentDate monthName;
 						onClick: (self jsGoToMonth: (Month indexOfMonth: aString) on: html);
 						desktopSize: 4;
@@ -312,9 +315,12 @@ MDLFlatDatePicker >> renderYearsOn: html [
 		mdlTypographyTextCenter;
 		with: [ self renderYearsHeaderOn: html.
 			self calendar yearsInterval
-				do: [ :aYear | 
+				do: [ :aYear |
 					html mdlCell
 						class: 'year-cell';
+						class: 'mdl-color-text--primary' if: aYear = self currentDate year;
+						class: 'mdl-color-text--primary-contrast' if: aYear = self currentDate year;
+						class: 'mdl-color--primary' if: aYear = self currentDate year;
 						class: 'active' if: aYear = self currentDate year;
 						onClick:
 							(html jQuery ajax


### PR DESCRIPTION
Added missing classes to highlight active month / year.

Fixes #186 