### PR TITLE
Simplify-expansion-panel-js

### DIFF
--- a/src/Material-Design-Lite-Widgets/MDLHideExpansionStrategy.class.st
+++ b/src/Material-Design-Lite-Widgets/MDLHideExpansionStrategy.class.st
@@ -18,7 +18,7 @@ MDLHideExpansionStrategy >> renderExpansionPanel: anExpansionPanel contentOn: ht
 MDLHideExpansionStrategy >> toggleScriptOn: htmlCanvas for: anExpansionPanel [
 	^ htmlCanvas jQuery
 		script: [ :jsScript |
-			jsScript << ((htmlCanvas jQuery id: anExpansionPanel id) toggleClass: 'isFolded').
+			jsScript << 'this.parentNode.classList.toggle("isFolded")' js.
 			anExpansionPanel expandIcon ~= anExpansionPanel foldIcon
 				ifTrue: [
 			jsScript << ('if($("#{id}").hasClass("isFolded"))\{


### PR DESCRIPTION
Simplify expansion panel JS using vanilla JS.

This will make it easier to make the expansion panel with brush work later when we will use CSS to manage the icon rotation.