### PR TITLE
293-MDLHighLevelWidgetstyle-is-broken

### DIFF
--- a/src/Material-Design-Lite-Widgets/MDLHighLevelWidget.class.st
+++ b/src/Material-Design-Lite-Widgets/MDLHighLevelWidget.class.st
@@ -110,5 +110,5 @@ MDLHighLevelWidget >> style: aString [
 						nextPutAll: aString ] ]
 		ifAbsent: [ aString ].
 
-	self propertiesAt: #style: put: stringToAdd
+	self propertiesAt: #style: put: {stringToAdd}
 ]


### PR DESCRIPTION
The propertiesAt:put: method now expect an array as second argument. 

Fixes #293