### PR TITLE
new test methods for MDLCalendarTest

### DIFF
--- a/src/Material-Design-Lite-Widgets-Tests/MDLCalendarTest.class.st
+++ b/src/Material-Design-Lite-Widgets-Tests/MDLCalendarTest.class.st
@@ -101,9 +101,25 @@ MDLCalendarTest >> testSelectNextMonth [
 ]
 
 { #category : #tests }
+MDLCalendarTest >> testSelectNextYears [
+	calendar currentDate: (Date year: 2016 month: 4 day: 10).
+	calendar selectNextYears.
+	self assert: calendar yearsInterval first equals: 2021.
+	self assert: calendar yearsInterval last equals: 2029
+]
+
+{ #category : #tests }
 MDLCalendarTest >> testSelectPreviousMonth [
 	calendar currentDate: (Date year: 2016 month: 4 day: 10).
 	calendar selectPreviousMonth.
 	self assert: calendar currentDate asMonth equals: (Month month: 3 year: 2016).
 	self assert: calendar currentDate equals: (Date year: 2016 month: 3 day: 10)
+]
+
+{ #category : #tests }
+MDLCalendarTest >> testSelectPreviousYears [
+	calendar currentDate: (Date year: 2016 month: 4 day: 10).
+	calendar selectPreviousYears.
+	self assert: calendar yearsInterval first equals: 2003.
+	self assert: calendar yearsInterval last equals: 2011
 ]


### PR DESCRIPTION
I submit this pull request to suggest two new test methods `MDLCalendarTest >> testSelectNextYears` and `MDLCalendarTest >> testPreviousYears`.

We noticed that the methods #selectNextYears and #selectPreviousYears are never executed by any of the tests in MDLCalendarTest. 

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
