### PR TITLE
improve: 'onComplete:' for ajax script of 'onClickJs:' can be customi…

### DIFF
--- a/src/Material-Design-Lite-Widgets-Tests/MDLNestedListTest.class.st
+++ b/src/Material-Design-Lite-Widgets-Tests/MDLNestedListTest.class.st
@@ -113,6 +113,21 @@ MDLNestedListTest >> testJsOnLoadHook [
 ]
 
 { #category : #tests }
+MDLNestedListTest >> testNotEraseOnCompleOnJSScript [
+	WAHtmlCanvas builder
+		render: [ :html | 
+			list elements: self sampleElements keys.
+			list
+				onClickJs: [ :entity | 
+					html jQuery ajax
+						serializeForm;
+						onComplete: 'console.log("this exists")' ] ].
+	self
+		assert: [ :html | html render: list ]
+		generatedIncludes: 'console.log(&quot;this exists&quot;)'
+]
+
+{ #category : #tests }
 MDLNestedListTest >> testRightIconBlockIsRenderedIfNeeded [
 	list elements: self sampleElements keys.
 	list rightIconBlock: [ :item :html | html mdlIcon: 'mood' ].

--- a/src/Material-Design-Lite-Widgets/MDLNestedList.class.st
+++ b/src/Material-Design-Lite-Widgets/MDLNestedList.class.st
@@ -484,6 +484,24 @@ MDLNestedList >> onLoadHook: anObject [
 	onLoadHook := anObject
 ]
 
+{ #category : #'as yet unclassified' }
+MDLNestedList >> overwriteOnCompleteForNode: aNode inDiv: div index: anIndex indentedBy: anInteger on: html [
+	| onClickValue selfOnComplete finalOnComplete |
+	onClickValue := self actionBlock value: aNode element.
+	selfOnComplete := (html jQuery id: div) load
+		html: [ :ajaxHtml | 
+			self
+				renderItemContentOf: aNode
+				index: anIndex
+				indentedBy: anInteger
+				on: ajaxHtml ].
+	[ finalOnComplete :=  selfOnComplete onComplete: (onClickValue options
+		at: 'complete' )]
+		on: GRError  do: [ finalOnComplete := selfOnComplete ].
+		onClickValue onComplete: finalOnComplete.
+		^ onClickValue 
+]
+
 { #category : #rendering }
 MDLNestedList >> printHtmlForElementsFrom: start to: end context: aContext on: stream [
 	self
@@ -534,31 +552,24 @@ MDLNestedList >> renderAnchor: aNode index: anIndex inDiv: div indentedBy: anInt
 	| anchor |
 	anchor := html anchor.
 	self actionBlock
-		ifNotNil: [ 
-			self isJsAction
-				ifTrue: [ 
-					anchor
+		ifNotNil: [ self isJsAction
+				ifTrue: [ anchor
 						onClick:
-							((self actionBlock value: aNode element)
-								onComplete:
-									((html jQuery id: div) load
-										html: [ :ajaxHtml | 
-											self
-												renderItemContentOf: aNode
-												index: anIndex
-												indentedBy: anInteger
-												on: ajaxHtml ])) ]
+							(self
+								overwriteOnCompleteForNode: aNode
+								inDiv: div
+								index: anIndex
+								indentedBy: anInteger
+								on: html) ]
 				ifFalse: [ anchor callback: [ self actionBlock value: aNode element ] ] ].
 	anchor
-		with: [ 
-			html span
+		with: [ html span
 				class: #item;
 				id: html nextId;
 				with: ((self format value: aNode element) ifEmpty: [ $  ]).
 			self renderHelpOf: aNode element at: html lastId on: html ].
 	aNode children
-		ifNotEmpty: [ 
-			html div
+		ifNotEmpty: [ html div
 				onClick: 'expandCollapse(this)';
 				class: #icon ]
 ]


### PR DESCRIPTION
#### Problem :
 When the user define something like : `onClickJs: [ :entity | ((html jQuery id: divId2) load html: [ :ajaxHtml | ajaxHtml text: 'Selected: ' , entity printString ])  onComplete: 'console.log("an action")']`  The nestedList erase the 'onComplete:' script with another script. 

#### Solution :
 The nestedList checks present of onComplete defined by user. If it exists, it keeps the user script after the nestedList script. In another case, it run only his script